### PR TITLE
Ruairi/kek implementation

### DIFF
--- a/services/file_service.py
+++ b/services/file_service.py
@@ -120,20 +120,9 @@ def share_file_with_user_service(file_info, recipient_username: str, user, priva
     # Use X25519 for key exchange
     recipient_identity_public = load_x25519_public_key(recipient_keys["x25519_identity_key_public"])
     recipient_signed_prekey_public = load_x25519_public_key(recipient_keys["signed_prekey_public"])
-    # # TODO remove this check in production
-    # recipient_user_local = User.query.filter_by(uuid=recipient_user['uuid']).first()
-    # print("Local recipient X25519 public key:", recipient_user_local.x25519_identity_key_public)
-    # print("Recipient keys x25519_identity_key_public:", recipient_keys["x25519_identity_key_public"])
-    # if recipient_user_local.x25519_identity_key_public != recipient_keys["x25519_identity_key_public"]:
-    #     raise ValueError("Recipient X25519 identity key public does not match local user record")
-    
-    # print(f"Recipient identity public key: {recipient_identity_public.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)}")
-    # print(f"Recipient signed prekey public key: {recipient_signed_prekey_public.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)}")
-
     
     ik_priv_bytes = user.get_x25519_identity_private_key(kek=kek)
     sender_ik_priv_x25519 = x25519.X25519PrivateKey.from_private_bytes(ik_priv_bytes)
-    print(f"\n=======\nSender X25519 identity public key: {sender_ik_priv_x25519.public_key().public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)}\n=======\n")
     if not isinstance(sender_ik_priv_x25519, x25519.X25519PrivateKey):
         raise ValueError("Sender identity private key is not of type X25519PrivateKey")
     shared_key = CryptoUtils.perform_3xdh_sender(
@@ -142,9 +131,6 @@ def share_file_with_user_service(file_info, recipient_username: str, user, priva
         recipient_identity_public=recipient_identity_public,
         recipient_signed_prekey_public=recipient_signed_prekey_public,
     )
-    # print(f"Shared key derived: {base64.b64encode(shared_key).decode()}")
-    print(f"3XDH sender performed")
-    print(f"Shared key: {base64.b64encode(shared_key).decode()}")
     
     enc_k_file_nonce, enc_k_file = CryptoUtils.encrypt_with_key(k_file, shared_key)
     

--- a/services/file_service.py
+++ b/services/file_service.py
@@ -120,12 +120,12 @@ def share_file_with_user_service(file_info, recipient_username: str, user, priva
     # Use X25519 for key exchange
     recipient_identity_public = load_x25519_public_key(recipient_keys["x25519_identity_key_public"])
     recipient_signed_prekey_public = load_x25519_public_key(recipient_keys["signed_prekey_public"])
-    # TODO remove this check in production
-    recipient_user_local = User.query.filter_by(uuid=recipient_user['uuid']).first()
-    print("Local recipient X25519 public key:", recipient_user_local.x25519_identity_key_public)
-    print("Recipient keys x25519_identity_key_public:", recipient_keys["x25519_identity_key_public"])
-    if recipient_user_local.x25519_identity_key_public != recipient_keys["x25519_identity_key_public"]:
-        raise ValueError("Recipient X25519 identity key public does not match local user record")
+    # # TODO remove this check in production
+    # recipient_user_local = User.query.filter_by(uuid=recipient_user['uuid']).first()
+    # print("Local recipient X25519 public key:", recipient_user_local.x25519_identity_key_public)
+    # print("Recipient keys x25519_identity_key_public:", recipient_keys["x25519_identity_key_public"])
+    # if recipient_user_local.x25519_identity_key_public != recipient_keys["x25519_identity_key_public"]:
+    #     raise ValueError("Recipient X25519 identity key public does not match local user record")
     
     # print(f"Recipient identity public key: {recipient_identity_public.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)}")
     # print(f"Recipient signed prekey public key: {recipient_signed_prekey_public.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)}")

--- a/utils/crypto_utils.py
+++ b/utils/crypto_utils.py
@@ -95,38 +95,6 @@ class CryptoUtils:
         recipient_one_time_prekey_public: x25519.X25519PublicKey = None,
     ) -> bytes:
         """Perform correct 3XDH key exchange as used in Signal."""
-        print("[3XDH SENDER]")
-        print("identity_private:", base64.b64encode(identity_private.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption()
-        )))
-        print("identity_private public:", base64.b64encode(identity_private.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("ephemeral_private:", base64.b64encode(ephemeral_private.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption()
-        )))
-        print("ephemeral_private public:", base64.b64encode(ephemeral_private.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("recipient_identity_public:", base64.b64encode(recipient_identity_public.public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("recipient_signed_prekey_public:", base64.b64encode(recipient_signed_prekey_public.public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        if recipient_one_time_prekey_public:
-            print("recipient_one_time_prekey_public:", base64.b64encode(recipient_one_time_prekey_public.public_bytes(
-                encoding=serialization.Encoding.Raw,
-                format=serialization.PublicFormat.Raw
-            )))
         shared1 = ephemeral_private.exchange(recipient_identity_public)
         shared2 = identity_private.exchange(recipient_signed_prekey_public)
         shared3 = ephemeral_private.exchange(recipient_signed_prekey_public)
@@ -151,43 +119,7 @@ class CryptoUtils:
         one_time_prekey_private: x25519.X25519PrivateKey = None    
         ) -> bytes:
         """Perform 3XDH from the receiver's side."""
-        print("[3XDH RECIPIENT]")
-        print("identity_private:", base64.b64encode(identity_private.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption()
-        )))
-        print("identity_private public:", base64.b64encode(identity_private.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("signed_prekey_private:", base64.b64encode(signed_prekey_private.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption()
-        )))
-        print("signed_prekey_private public:", base64.b64encode(signed_prekey_private.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("sender_identity_public:", base64.b64encode(sender_identity_public.public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        print("sender_ephemeral_public:", base64.b64encode(sender_ephemeral_public.public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw
-        )))
-        if one_time_prekey_private:
-            print("one_time_prekey_private:", base64.b64encode(one_time_prekey_private.private_bytes(
-                encoding=serialization.Encoding.Raw,
-                format=serialization.PrivateFormat.Raw,
-                encryption_algorithm=serialization.NoEncryption()
-            )))
-            print("one_time_prekey_private public:", base64.b64encode(one_time_prekey_private.public_key().public_bytes(
-                encoding=serialization.Encoding.Raw,
-                format=serialization.PublicFormat.Raw
-            )))
+        
         shared1 = identity_private.exchange(sender_ephemeral_public)
         shared2 = signed_prekey_private.exchange(sender_identity_public)
         shared3 = signed_prekey_private.exchange(sender_ephemeral_public)
@@ -273,8 +205,6 @@ class CryptoUtils:
             signature = base64.b64decode(pac["signature"])
             pac_copy = CryptoUtils.canonicalize_pac_dict(pac)
             message = json.dumps(pac_copy, sort_keys=True).encode()
-            # print(f"PAC verification signature: {signature}")
-            # print(f"PAC verification message:{message}")
             issuer_public_key.verify(signature, message)
             return True
         except Exception:


### PR DESCRIPTION
This pull request focuses on cleaning up debugging and logging code, specifically by removing print statements used for debugging cryptographic operations and key exchanges. These changes improve code readability and prepare the codebase for production use.

### Debugging cleanup:

* `services/file_service.py`:
  - Removed print statements that logged sensitive information, such as public keys and shared keys, during the `share_file_with_user_service` function. This includes removing a local user key validation check that was intended for debugging purposes. [[1]](diffhunk://#diff-34341dbbd955b604b5f63a02923b0f87a7e08ef096ab834203d33fc4e8fc2216L123-L136) [[2]](diffhunk://#diff-34341dbbd955b604b5f63a02923b0f87a7e08ef096ab834203d33fc4e8fc2216L145-L147)

* `utils/crypto_utils.py`:
  - Eliminated extensive debugging print statements from the `perform_3xdh_sender` and `perform_3xdh_recipient` functions, which previously logged private and public key details during the 3XDH key exchange process. [[1]](diffhunk://#diff-6a7aa499f3092e1c834dd383f476f7884f1490de8bbe31dc911d4395c3200c97L98-L129) [[2]](diffhunk://#diff-6a7aa499f3092e1c834dd383f476f7884f1490de8bbe31dc911d4395c3200c97L154-R122)
  - Removed commented-out print statements in the `verify_pac` function that logged PAC verification details.